### PR TITLE
withVerifyDir is not required for gitDirectory and breaks support for bare repos

### DIFF
--- a/Data/FileStore/Git.hs
+++ b/Data/FileStore/Git.hs
@@ -172,7 +172,7 @@ gitIndex repo = withVerifyDir repo $ do
 
 -- | Get list of resources in one directory of the repository.
 gitDirectory :: FilePath -> FilePath -> IO [Resource]
-gitDirectory repo dir = withVerifyDir (repo </> dir) $ do
+gitDirectory repo dir = do
   (status, _err, output) <- runGitCommand repo "ls-tree" ["-z","HEAD:" ++ dir]
   if status == ExitSuccess
      then return $ map (lineToResource . words) $ endByOneOf ['\0'] $ toString output

--- a/filestore.cabal
+++ b/filestore.cabal
@@ -1,5 +1,5 @@
 Name:                filestore
-Version:             0.6-coconnor
+Version:             0.6.1
 Cabal-Version:       >= 1.10
 Build-type:          Custom
 Synopsis:            Interface for versioning file stores.


### PR DESCRIPTION
Maybe "withVerifyDir repo" is still required?
