### PR TITLE
post-update is a bash script

### DIFF
--- a/extra/post-update
+++ b/extra/post-update
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # This hook does two things:
 #


### PR DESCRIPTION
and not a generic shell script, so mark it as such. This was reported by Raphael Geissert as http://bugs.debian.org/72323.
