### PR TITLE
filestore.cabal: refresh for ghc-8

### DIFF
--- a/Data/FileStore/Types.hs
+++ b/Data/FileStore/Types.hs
@@ -150,7 +150,7 @@ data FileStore = FileStore {
     initialize     :: IO ()
 
     -- | Save contents in the filestore.
-  , save           :: Contents a
+  , save           :: forall a . Contents a
                    => FilePath          -- Resource to save.
                    -> Author            --  Author of change.
                    -> Description       --  Description of change.
@@ -158,7 +158,7 @@ data FileStore = FileStore {
                    -> IO ()
 
     -- | Retrieve the contents of the named resource.
-  , retrieve       :: Contents a
+  , retrieve       :: forall a . Contents a
                    => FilePath          -- Resource to retrieve.
                    -> Maybe RevisionId  -- @Just@ a particular revision ID,
                                         -- or @Nothing@ for latest

--- a/filestore.cabal
+++ b/filestore.cabal
@@ -35,8 +35,8 @@ Library
                          filepath >= 1.1 && < 1.5,
                          directory >= 1.0 && < 1.3,
                          parsec >= 2 && < 3.2,
-                         process >= 1.0 && < 1.3,
-                         time >= 1.1 && < 1.6,
+                         process >= 1.0 && < 1.5,
+                         time >= 1.1 && < 1.7,
                          xml >= 1.3 && < 1.4,
                          split >= 0.1 && < 0.3,
                          Diff >= 0.2 && < 0.4,
@@ -65,7 +65,7 @@ Test-suite test-filestore
     Main-is:        Tests.hs
     Default-Language:  Haskell98
     Build-depends:  base >= 4 && < 5,
-                    HUnit >= 1.2 && < 1.3,
+                    HUnit >= 1.2 && < 1.4,
                     mtl,
                     time,
                     Diff >= 0.2 && < 0.4,


### PR DESCRIPTION
GHC now requires explicit quantification.

Patch fixes the following build failure:
  [ 3 of 11] Compiling Data.FileStore.Types ( Data/FileStore/Types.hs, dist/build/Data/FileStore/Types.o )

  Data/FileStore/Types.hs:153:32: error:
    Not in scope: type variable ‘a’

Updated upper bounds for packages bundled with ghc-8.

Signed-off-by: Sergei Trofimovich <siarheit@google.com>