### PR TITLE
Use build-type:Simple

### DIFF
--- a/filestore.cabal
+++ b/filestore.cabal
@@ -1,7 +1,7 @@
 Name:                filestore
 Version:             0.6.3.2
 Cabal-Version:       >= 1.10
-Build-type:          Custom
+Build-type:          Simple
 Synopsis:            Interface for versioning file stores.
 Description:         The filestore library provides an abstract interface for a versioning
                      file store, and modules that instantiate this interface.  Currently


### PR DESCRIPTION
This switches build-type to Simple since this package uses a trivial
default Setup.hs anyway; so build-type:custom causes unecessary
overhead for cabal (and would require defining a `custom-setup` stanza
to be compatible with recent GHCs), as it needs to solve, compile, link,
and execute an external Setup.hs script, rather than simply use its
internal "Simple" mode.