### PR TITLE
Raise `Diff` upper bound

### DIFF
--- a/filestore.cabal
+++ b/filestore.cabal
@@ -39,7 +39,7 @@ Library
                          time >= 1.5 && < 1.13,
                          xml >= 1.3 && < 1.4,
                          split >= 0.1 && < 0.3,
-                         Diff >= 0.4 && < 0.5,
+                         Diff >= 0.4 && < 0.6,
                          old-locale >= 1.0 && < 1.1
 
     Exposed-modules:     Data.FileStore
@@ -72,8 +72,7 @@ Test-suite test-filestore
                     HUnit >= 1.2 && < 1.7,
                     mtl,
                     time,
-                    Diff >= 0.4 && < 0.5,
+                    Diff >= 0.4 && < 0.6,
                     filepath >= 1.1 && < 1.5,
                     directory >= 1.1 && < 1.4,
                     filestore
-


### PR DESCRIPTION
Our internal code raises this bound with `allow-newer`, and `cabal test --constraint 'Diff ^>=0.5'` passes.

Can we please also have a Hackage metadata revision for this?